### PR TITLE
Support ruby 3

### DIFF
--- a/lib/artisanal/model/dsl.rb
+++ b/lib/artisanal/model/dsl.rb
@@ -9,7 +9,7 @@ module Artisanal::Model
     end
 
     def inherited(subclass)
-      subclass.include Artisanal::Model(artisanal_model.config.options)
+      subclass.include Artisanal::Model(**artisanal_model.config.options)
       super(subclass)
     end
 
@@ -21,8 +21,8 @@ module Artisanal::Model
       artisanal_model.schema
     end
 
-    def attribute(*args)
-      artisanal_model.attribute(*args)
+    def attribute(*args, **kwargs)
+      artisanal_model.attribute(*args, **kwargs)
     end
 
     module InstanceMethods
@@ -34,8 +34,8 @@ module Artisanal::Model
         artisanal_model.attributes(self, *args)
       end
 
-      def to_h(*args)
-        artisanal_model.to_h(self, *args)
+      def to_h(**args)
+        artisanal_model.to_h(self, **args)
       end
     end
   end

--- a/lib/artisanal/model/initializer.rb
+++ b/lib/artisanal/model/initializer.rb
@@ -1,7 +1,7 @@
 module Artisanal::Model
   module Initializer
     def initialize(attributes={}, parent=nil)
-      super(artisanal_model.symbolize(attributes))
+      super(**artisanal_model.symbolize(attributes))
     end
   end
 end


### PR DESCRIPTION
Add support for Ruby 3. 
Specifically, fix a bunch of deprecation messages in Ruby 2.7.7 about separation of positional and keyword arguments, which become ArgumentErrors in Ruby 3.0